### PR TITLE
Fixed Editor Window Not Cleared at Asset Deletion

### DIFF
--- a/Editor/Views/BehaviourTreeView.cs
+++ b/Editor/Views/BehaviourTreeView.cs
@@ -85,6 +85,15 @@ public partial class BehaviourTreeView : GraphView
         LoadViewTransform();
     }
 
+    public void ClearView()
+    {
+        _BehaviourTree = null;
+        _SerializedTree = null;
+        _RootNodeView = null;
+        ClearGraph();
+        _BlackboardView.ClearView();
+    }
+
     private void ClearGraph()
     {
         graphViewChanged -= OnGraphViewChange;

--- a/Editor/Windows/BehaviourTreeEditor.cs
+++ b/Editor/Windows/BehaviourTreeEditor.cs
@@ -1,9 +1,11 @@
-using UnityEditor;
-using UnityEditor.Callbacks;
-using UnityEngine;
-using UnityEngine.UIElements;
 using MoshitinEncoded.AI;
 using MoshitinEncoded.AI.BehaviourTreeLib;
+
+using UnityEditor;
+using UnityEditor.Callbacks;
+
+using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace MoshitinEncoded.Editor.AI.BehaviourTreeLib
 {
@@ -35,6 +37,14 @@ namespace MoshitinEncoded.Editor.AI.BehaviourTreeLib
             wnd.titleContent = new GUIContent("Behaviour Tree");
         }
 
+        private void OnAssetDeleted()
+        {
+            if (_BehaviourTree == null && !Application.isPlaying)
+            {
+                _TreeView.ClearView();
+            }
+        }
+
         public void CreateGUI()
         {
             // Each editor window contains a root VisualElement object
@@ -58,11 +68,13 @@ namespace MoshitinEncoded.Editor.AI.BehaviourTreeLib
         {
             EditorApplication.playModeStateChanged -= OnPlayModeStateChange;
             EditorApplication.playModeStateChanged += OnPlayModeStateChange;
+            BehaviourTreeAssetProcessor.AssetDeleted += OnAssetDeleted;
         }
 
         private void OnDisable()
         {
             EditorApplication.playModeStateChanged -= OnPlayModeStateChange;
+            BehaviourTreeAssetProcessor.AssetDeleted -= OnAssetDeleted;
             SaveWindowState();
         }
 


### PR DESCRIPTION
Added:

- An event in `BehaviourTreeAssetProcessor` for when an asset is deleted
- A method in `BehaviourTreeEditor` to manage the event
- A clearing method in `BehaviourTreeView` to clear the graph and blackboard